### PR TITLE
レシピ投稿の不具合の修正

### DIFF
--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -2,7 +2,7 @@ class Recipe < ApplicationRecord
   before_validation :normalize_required_time
 
   belongs_to :family
-  belongs_to :member
+  belongs_to :member, optional: true
 
   has_many :recipe_tags, dependent: :destroy
   has_many :tags, through: :recipe_tags

--- a/app/views/recipes/_form.html.erb
+++ b/app/views/recipes/_form.html.erb
@@ -76,7 +76,7 @@
             class: "text-sm text-blue-600 underline" %>
       </div>
       <%= f.collection_select :member_id, current_family.members, :id, :name,
-          { prompt: "誰が投稿しますか？" },
+          { prompt: "誰が投稿しますか？（未選択可）" },
           class: "w-full p-4 text-lg border rounded-xl" %>
       </div>
 


### PR DESCRIPTION
## 概要
- レシピ登録の際にメンバーを入力しないと登録できなかったので未選択でも登録できるようにしました。